### PR TITLE
fix sickle-collected items so they can grow too

### DIFF
--- a/lib/api.lua
+++ b/lib/api.lua
@@ -75,6 +75,8 @@ function sickles.register_trimmable(node, base)
 			end
 			local param2 = minetest.registered_nodes[base].place_param2
 			minetest.set_node(pos, { name = base, param2 = param2 })
+			-- timer values taken from farming mod (see tick function in api.lua)
+			minetest.get_node_timer(pos):start(math.random(166, 286))
 		end
 	})
 end


### PR DESCRIPTION
fixes #9, by duplicating 64f88263e223c0eb22a0721cda0e9680c65f5267 in function harvest_and_replant