### PR TITLE
Add compatibility for mineclonia

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,7 @@ in the supplied license file.
 Textures for tools and moss items are made by Cap for this mod and licensed under *CC BY-SA 3.0*.
 Textures for placed moss node and flower petals are by Vanessa Ezekowitz under *CC BY-SA 4.0* for her [plantlife modpack](https://forum.minetest.net/viewtopic.php?t=3898).
 The sound effect for placing or breaking moss blocks is made by DrMinky under *CC BY 3.0* and can be found on [FreeSound](https://freesound.org/people/DrMinky/sounds/167073/).
+
+## Changes
+
+* Now supports [Mineclonia](https://content.luanti.org/packages/ryvnf/mineclonia/)!

--- a/lib/api.lua
+++ b/lib/api.lua
@@ -172,6 +172,12 @@ local function harvest_and_replant(pos, player)
 				local level1 = node_id .. "_1"
 				-- keep the same paramtype2 = "meshoptions" from lua_api.md
 				minetest.set_node(pos, { name = level1, param2 = node.param2 })
+				-- need to remove seed again for Mineclonia, because it dropped seeds.
+				minetest.after(0,function()
+					if not is_creative(playername) then
+						invref:remove_item("main", seeds)
+					end
+				end)
 			else
 				minetest.set_node(pos, { name = seeds, param2 = 1 })
 			end

--- a/lib/api.lua
+++ b/lib/api.lua
@@ -75,6 +75,8 @@ function sickles.register_trimmable(node, base)
 			end
 			local param2 = minetest.registered_nodes[base].place_param2
 			minetest.set_node(pos, { name = base, param2 = param2 })
+			-- timer values taken from farming mod (see tick function in api.lua)
+			minetest.get_node_timer(pos):start(math.random(166, 286))
 		end
 	})
 end

--- a/lib/compatibility.lua
+++ b/lib/compatibility.lua
@@ -3,6 +3,7 @@ local mod_bonemeal = minetest.get_modpath("bonemeal") ~= nil
 local mod_trunks = minetest.get_modpath("trunks") ~= nil
 local mod_cottages = minetest.get_modpath("cottages") ~= nil
 local mod_gloopblocks = minetest.get_modpath("gloopblocks") ~= nil
+local mod_mcl_bone_meal = minetest.get_modpath("mcl_bone_meal") ~= nil
 
 -- turn moss into fertilizer by cooking
 if mod_bonemeal then
@@ -10,6 +11,14 @@ if mod_bonemeal then
 		type = "cooking",
 		cooktime = 9,
 		output = "bonemeal:fertiliser",
+		recipe = "group:moss"
+	})
+end
+if mod_mcl_bone_meal then
+	minetest.register_craft({
+		type = "cooking",
+		cooktime = 9,
+		output = "mcl_bone_meal:bone_meal",
 		recipe = "group:moss"
 	})
 end

--- a/lib/cuttables.lua
+++ b/lib/cuttables.lua
@@ -14,7 +14,15 @@ local mod_df_primordial_items = minetest.get_modpath("df_primordial_items") ~= n
 local mod_ethereal = minetest.get_modpath("ethereal") ~= nil
 local mod_gloopblocks = minetest.get_modpath("gloopblocks") ~= nil
 local mod_underch = minetest.get_modpath("underch") ~= nil
+local mod_mcl_core = minetest.get_modpath("mcl_core") ~= nil
+local mod_mcl_walls = minetest.get_modpath("mcl_walls") ~= nil
+local mod_mcl_stairs = minetest.get_modpath("mcl_stairs") ~= nil
+local mod_mcl_farming = minetest.get_modpath("mcl_farming") ~= nil
 
+if mod_mcl_core then
+sickles.register_cuttable("mcl_core:dirt_with_grass", "mcl_core:dirt", "mcl_flowers:double_grass")
+sickles.register_cuttable("mcl_core:mossycobble", "mcl_core:cobble", "sickles:moss")
+else -- default
 sickles.register_cuttable("default:dirt_with_grass", "default:dirt", "default:grass_1")
 sickles.register_cuttable("default:dirt_with_dry_grass", "default:dirt", "default:dry_grass_1")
 sickles.register_cuttable("default:dry_dirt_with_dry_grass", "default:dry_dirt", "default:dry_grass_1")
@@ -22,11 +30,21 @@ sickles.register_cuttable("default:dirt_with_rainforest_litter", "default:dirt",
 sickles.register_cuttable("default:dirt_with_coniferous_litter", "default:dirt", "default:dry_grass_1")
 sickles.register_cuttable("default:permafrost_with_moss", "default:permafrost", "sickles:moss")
 sickles.register_cuttable("default:mossycobble", "default:cobble", "sickles:moss")
+end
 
+if mod_mcl_walls then
+	sickles.register_cuttable("mcl_walls:mossycobble", "mcl_walls:cobble", "sickles:moss")
+end
 if mod_walls then
 	sickles.register_cuttable("walls:mossycobble", "walls:cobble", "sickles:moss")
 end
 
+if mod_mcl_stairs then
+	sickles.register_cuttable("mcl_stairs:slab_mossycobble", "mcl_stairs:slab_cobble", "sickles:moss")
+	sickles.register_cuttable("mcl_stairs:stair_mossycobble", "mcl_stairs:stair_cobble", "sickles:moss")
+	sickles.register_cuttable("mcl_stairs:stair_inner_mossycobble", "mcl_stairs:stair_inner_cobble", "sickles:moss")
+	sickles.register_cuttable("mcl_stairs:stair_outer_mossycobble", "mcl_stairs:stair_outer_cobble", "sickles:moss")
+end
 if mod_stairs then
 	sickles.register_cuttable("stairs:slab_mossycobble", "stairs:slab_cobble", "sickles:moss")
 	sickles.register_cuttable("stairs:stair_mossycobble", "stairs:stair_cobble", "sickles:moss")
@@ -56,6 +74,10 @@ if mod_woodsoils then
 	sickles.register_cuttable("woodsoils:grass_with_leaves_2", "default:dirt", "default:dry_grass_1")
 end
 
+if mod_mcl_farming then
+	sickles.register_trimmable("mcl_farming:wheat", "mcl_farming:wheat_2")
+	-- one does not use a sickle for beetroots, pumpkins, or melons
+end
 if mod_farming then
 	sickles.register_trimmable("farming:wheat_8", "farming:wheat_2")
 end

--- a/lib/items.lua
+++ b/lib/items.lua
@@ -1,5 +1,14 @@
 local mod_stairs = minetest.get_modpath("stairs") ~= nil
+local mod_mcl_stairs = minetest.get_modpath("mcl_stairs") ~= nil
 local mod_dye = minetest.get_modpath("dye") ~= nil
+local mod_mcl_dyes = minetest.get_modpath("mcl_dyes") ~= nil
+local mod_mcl_lush_caves = minetest.get_modpath("mcl_lush_caves") ~= nil
+local mod_mcl_sounds = minetest.get_modpath("mcl_sounds") ~= nil
+
+local default_moss_png = "default_moss.png"
+if mod_mcl_lush_caves then
+	default_moss_png = "mcl_lush_caves_moss.png"
+end
 
 local S = sickles.i18n
 
@@ -10,11 +19,20 @@ local colors = {
 	{ hex = "#bcc56770", name = "yellow", dye = "yellow" }
 }
 
-local sounds = default.node_sound_leaves_defaults({
+local sounds
+if mod_mcl_sounds then
+sounds = mcl_sounds.node_sound_leaves_defaults({
 	footstep = "default_grass_footstep",
 	dug = "sickles_moss_dug",
 	place = "sickles_moss_dug"
 })
+else
+sounds = default.node_sound_leaves_defaults({
+	footstep = "default_grass_footstep",
+	dug = "sickles_moss_dug",
+	place = "sickles_moss_dug"
+})
+end
 
 local node_box = {
 	type = "wallmounted",
@@ -24,6 +42,15 @@ local node_box = {
 }
 
 local function register_stairs(subname, recipeitem, groups, images, desc_stair, desc_slab, desc_slope, snds, wat)
+	if mod_mcl_stairs then
+	mcl_stairs.register_stair_and_slab(subname, {
+		baseitem = recipeitem,
+		description_stair = desc_stair,
+		description_slab = desc_slab,
+		groups = groups,
+		sounds = snds
+	})
+	end
 	if not mod_stairs then return end
 	stairs.register_stair_and_slab(subname, recipeitem, groups, images, desc_stair, desc_slab, snds, wat)
 	if stairs.mod == "redo" then
@@ -66,7 +93,7 @@ for _, color in ipairs(colors) do
 
 	minetest.register_node("sickles:moss_block" .. name_suffix, {
 		description = S(display_name_prefix .. "Moss Block"),
-		tiles = { "default_moss.png" .. texture_overlay },
+		tiles = { default_moss_png .. texture_overlay },
 		is_ground_content = false,
 		groups = { snappy = 3, moss_block = 1, flammable = 2, fall_damage_add_percent = -80 },
 		sounds = sounds
@@ -76,7 +103,7 @@ for _, color in ipairs(colors) do
 		"moss_block" .. name_suffix,
 		"sickles:moss_block" .. name_suffix,
 		{ snappy = 3, flammable = 2, fall_damage_add_percent = -80 },
-		{ "default_moss.png" .. texture_overlay },
+		{ default_moss_png .. texture_overlay },
 		S(display_name_prefix .. "Moss Stair"),
 		S(display_name_prefix .. "Moss Slab"),
 		S(display_name_prefix .. "Moss Slope"),
@@ -109,6 +136,18 @@ for _, color in ipairs(colors) do
 			recipe = {{ "sickles:moss" .. name_suffix }}
 		})
 	end
+	if mod_mcl_dyes then
+		minetest.register_craft({
+			type = "shapeless",
+			output = "sickles:moss_block" .. name_suffix,
+			recipe = { "group:moss_block", "mcl_dyes:" .. color.dye }
+		})
+
+		minetest.register_craft({
+			output = "mcl_dyes:" .. color.dye,
+			recipe = {{ "sickles:moss" .. name_suffix }}
+		})
+	end
 end
 
 minetest.register_craft({
@@ -123,6 +162,12 @@ minetest.register_craft({
 	burntime = 18
 })
 
+local use_sounds
+if mod_mcl_sounds then
+	use_sounds = mcl_sounds.node_sound_leaves_defaults()
+else
+	use_sounds = default.node_sound_leaves_defaults()
+end
 minetest.register_node("sickles:petals", {
 	description = S("Flower Petals"),
 	tiles = { "nature_blossom.png" },
@@ -130,7 +175,7 @@ minetest.register_node("sickles:petals", {
 	wield_image = "nature_blossom.png",
 	is_ground_content = false,
 	groups = { snappy = 3, attached_node = 1 },
-	sounds = default.node_sound_leaves_defaults(),
+	sounds = use_sounds,
 	use_texture_alpha = true,
 	drawtype = "signlike",
 	paramtype = "light",

--- a/lib/tools.lua
+++ b/lib/tools.lua
@@ -1,8 +1,136 @@
 local is_farming_redo = minetest.get_modpath("farming") ~= nil
 		and farming ~= nil and farming.mod == "redo"
+local mod_mcl_core = minetest.get_modpath("mcl_core") ~= nil
+local mod_mcl_copper = minetest.get_modpath("mcl_copper") ~= nil
 
 local S = sickles.i18n
 
+if mod_mcl_core then
+minetest.register_tool("sickles:sickle_gold", {
+	description = S("Golden Sickle"),
+	inventory_image = "sickles_sickle_gold.png",
+	tool_capabilities = {
+		full_punch_interval = 0.8,
+		max_drop_level = 1,
+		groupcaps = {
+			snappy = { times = { [1] = 2.0, [2] = 1.00, [3] = 0.35 }, uses = 80, maxlevel = 3 }
+		},
+		damage_groups = { fleshy = 2 },
+		punch_attack_uses = 80
+	},
+	range = 6,
+	groups = { sickle = 1, sickle_uses = 160 },
+	sound = { breaks = "default_tool_breaks" }
+})
+
+minetest.register_craft({
+	output = "sickles:sickle_gold",
+	recipe = {
+		{ "mcl_core:gold_ingot", "" },
+		{ "", "mcl_core:gold_ingot" },
+		{ "group:stick", "" }
+	}
+})
+
+minetest.register_tool("sickles:sickle_iron", {
+	description = S("Iron Sickle"),
+	inventory_image = "sickles_sickle_steel.png",
+	tool_capabilities = {
+		full_punch_interval = 0.8,
+		max_drop_level = 1,
+		groupcaps = {
+			snappy = { times = { [1] = 2.5, [2] = 1.20, [3] = 0.35 }, uses = 150, maxlevel = 2 }
+		},
+		damage_groups = { fleshy = 3 },
+		punch_attack_uses = 150
+	},
+	range = 6,
+	groups = { sickle = 1, sickle_uses = 300 },
+	sound = { breaks = "default_tool_breaks" }
+})
+
+minetest.register_craft({
+	output = "sickles:sickle_iron",
+	recipe = {
+		{ "mcl_core:iron_ingot", "" },
+		{ "", "mcl_core:iron_ingot" },
+		{ "group:stick", "" }
+	}
+})
+
+minetest.register_tool("sickles:sickle_copper", {
+	description = S("Copper Sickle"),
+	inventory_image = "sickles_sickle_bronze.png",
+	tool_capabilities = {
+		full_punch_interval = 0.8,
+		max_drop_level = 1,
+		groupcaps = {
+			snappy = { times = { [1] = 2.75, [2] = 1.30, [3] = 0.375 }, uses = 100, maxlevel = 2 }
+		},
+		damage_groups = { fleshy = 3 },
+		punch_attack_uses = 100
+	},
+	range = 6,
+	groups = { sickle = 1, sickle_uses = 200 },
+	sound = { breaks = "default_tool_breaks" }
+})
+
+minetest.register_craft({
+	output = "sickles:sickle_copper",
+	recipe = {
+		{ "mcl_copper:copper_ingot", "" },
+		{ "", "mcl_copper:copper_ingot" },
+		{ "group:stick", "" }
+	}
+})
+
+minetest.register_tool("sickles:scythe_copper", {
+	description = S("Copper Scythe"),
+	inventory_image = "sickles_scythe_bronze.png",
+	tool_capabilities = {
+		full_punch_interval = 1.2,
+		damage_groups = { fleshy = 5 },
+		punch_attack_uses = 200
+	},
+	range = 12,
+	on_use = sickles.use_scythe,
+	groups = { scythe = 2, scythe_uses = 100 },
+	sound = { breaks = "default_tool_breaks" }
+})
+
+minetest.register_craft({
+	output = "sickles:scythe_copper",
+	recipe = {
+		{ "", "mcl_copper:copper_ingot", "mcl_copper:copper_ingot" },
+		{ "mcl_copper:copper_ingot", "", "group:stick" },
+		{ "", "", "group:stick" }
+	}
+})
+
+minetest.register_tool("sickles:scythe_iron", {
+	description = S("Iron Scythe"),
+	inventory_image = "sickles_scythe_steel.png",
+	tool_capabilities = {
+		full_punch_interval = 1.2,
+		damage_groups = { fleshy = 5 },
+		punch_attack_uses = 300
+	},
+	range = 12,
+	on_use = sickles.use_scythe,
+	groups = { scythe = 2, scythe_uses = 150 },
+	sound = { breaks = "default_tool_breaks" }
+})
+
+minetest.register_craft({
+	output = "sickles:scythe_iron",
+	recipe = {
+		{ "", "mcl_core:iron_ingot", "mcl_core:iron_ingot" },
+		{ "mcl_core:iron_ingot", "", "group:stick" },
+		{ "", "", "group:stick" }
+	}
+})
+
+else -- for minetest_game
 minetest.register_tool("sickles:sickle_bronze", {
 	description = S("Bronze Sickle"),
 	inventory_image = "sickles_sickle_bronze.png",
@@ -126,6 +254,7 @@ minetest.register_craft({
 		{ "", "", "group:stick" }
 	}
 })
+end
 
 if is_farming_redo then
 	-- softly disable mithril scythe to prevent confusion

--- a/mod.conf
+++ b/mod.conf
@@ -9,4 +9,4 @@ They also replant harvested crops automatically. Alternatively, they can be used
 Sickles allow you to scrape grass and moss from overgrown nodes. The resulting moss can then be used as dye of fertilizer.
 They also let you to cut wheat and other grains more precisely, allowing you to harvest some crops without completely resetting them.
 """
-optional_depends = default, farming, stairs, walls, cottages, dye, flowers, footprints, bonemeal, nature_classic, moretrees, trunks, grains, cucina_vegana, df_mapitems, df_primordial_items, caverealms, ethereal, gloopblocks, underch, mcl_lush_caves
+optional_depends = bonemeal caverealms cottages cucina_vegana df_mapitems df_primordial_items dye ethereal farming flowers footprints gloopblocks grains mcl_bone_meal mcl_copper mcl_core mcl_dyes mcl_farming mcl_lush_caves mcl_sounds mcl_stairs mcl_walls moretrees nature_classic stairs trunks underch walls woodsoils

--- a/mod.conf
+++ b/mod.conf
@@ -9,4 +9,5 @@ They also replant harvested crops automatically. Alternatively, they can be used
 Sickles allow you to scrape grass and moss from overgrown nodes. The resulting moss can then be used as dye of fertilizer.
 They also let you to cut wheat and other grains more precisely, allowing you to harvest some crops without completely resetting them.
 """
-optional_depends = bonemeal caverealms cottages cucina_vegana df_mapitems df_primordial_items dye ethereal farming flowers footprints gloopblocks grains mcl_bone_meal mcl_copper mcl_core mcl_dyes mcl_farming mcl_lush_caves mcl_sounds mcl_stairs mcl_walls moretrees nature_classic stairs trunks underch walls woodsoils
+# derived with grep -h -o -P "(?<=get_modpath\((['\"]))\w+(?=\1\))" lib/*lua | sort | uniq | tr '\n' ','
+optional_depends = bonemeal,caverealms,cottages,cucina_vegana,df_mapitems,df_primordial_items,dye,ethereal,farming,flowers,footprints,gloopblocks,grains,mcl_bone_meal,mcl_copper,mcl_core,mcl_dyes,mcl_farming,mcl_lush_caves,mcl_sounds,mcl_stairs,mcl_walls,moretrees,nature_classic,stairs,trunks,underch,walls,woodsoils

--- a/mod.conf
+++ b/mod.conf
@@ -9,5 +9,4 @@ They also replant harvested crops automatically. Alternatively, they can be used
 Sickles allow you to scrape grass and moss from overgrown nodes. The resulting moss can then be used as dye of fertilizer.
 They also let you to cut wheat and other grains more precisely, allowing you to harvest some crops without completely resetting them.
 """
-depends = default, farming
-optional_depends = stairs, walls, cottages, dye, flowers, footprints, bonemeal, nature_classic, moretrees, trunks, grains, cucina_vegana, df_mapitems, df_primordial_items, caverealms, ethereal, gloopblocks, underch
+optional_depends = default, farming, stairs, walls, cottages, dye, flowers, footprints, bonemeal, nature_classic, moretrees, trunks, grains, cucina_vegana, df_mapitems, df_primordial_items, caverealms, ethereal, gloopblocks, underch, mcl_lush_caves


### PR DESCRIPTION
* Tested scythe and sickle against wheat, the only base wheat-like crop in Mineclonia and also the only crop that makes sense to gather with a sickle
* Tested sickle for scraping moss off various blocks
* Tested moss colors, stairs, cooking into bonemeal (the fertiliser for Mineclonia), and eating.

In other words, I believe every feature described is implemented successfully for Mineclonia, and still operable in Minetest Game.